### PR TITLE
Fix PHP warning after activation

### DIFF
--- a/bento-helper.php
+++ b/bento-helper.php
@@ -3,7 +3,7 @@
  * Plugin Name: Bento Helper
  * Plugin URI: https://github.com/bentonow/bento-wordpress-sdk
  * Description: Email marketing, live chat, and analytics for WooCommerce stores.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: Bento
  * Author URI: https://bentonow.com
  * Text Domain: bentonow
@@ -19,7 +19,7 @@ class Bento_Helper {
 	 *
 	 * @var string
 	 */
-	public $version = '1.0.1';
+	public $version = '1.0.2';
 
 	/**
 	 * URL dir for plugin.

--- a/inc/custom.php
+++ b/inc/custom.php
@@ -8,7 +8,7 @@ class Bento_Custom
   /**
    * Current version of Bento.
    */
-  public $version = '1.0.1';
+  public $version = '1.0.2';
 
   public function __construct()
   {
@@ -20,12 +20,17 @@ class Bento_Custom
    */
   public function scripts_styles()
   {
-    $bento_options = get_option('bento_settings');
-    $bento_site_key = $bento_options['bento_site_key'];
+    $bento_options = get_option( 'bento_settings' );
 
-    if (empty($bento_site_key)) {
+    if (
+      ! $bento_options ||
+      ! array_key_exists( 'bento_site_key', $bento_options ) ||
+      empty( $bento_site_key )
+    ) {
       return;
     }
+
+    $bento_site_key = $bento_options['bento_site_key'];
 
     wp_enqueue_script(
       'bento-js',

--- a/inc/custom.php
+++ b/inc/custom.php
@@ -25,7 +25,7 @@ class Bento_Custom
     if (
       ! $bento_options ||
       ! array_key_exists( 'bento_site_key', $bento_options ) ||
-      empty( $bento_site_key )
+      empty( $bento_options['bento_site_key'] )
     ) {
       return;
     }

--- a/inc/orders.php
+++ b/inc/orders.php
@@ -20,17 +20,17 @@ class Bento_Helper_Orders
      // These are standard WooCommerce hooks
     // https://woocommerce.com/document/subscriptions/develop/action-reference/
     add_action('woocommerce_thankyou', [$this, 'send_order_placed_event']);
-    
+
     add_action('woocommerce_order_status_completed', [
       $this,
       'send_order_shipped_event',
     ]);
-    
+
     add_action('woocommerce_order_status_cancelled', [
       $this,
       'send_order_cancelled_event',
     ]);
-    
+
     add_action('woocommerce_order_refunded', [
       $this,
       'send_order_refunded_event',
@@ -92,7 +92,7 @@ class Bento_Helper_Orders
 
   public function send_woocommerce_subscription_status_active_event($subscription)
   {
-    $order = 
+    $order =
     $this->sendSubscriptionEvent('$SubscriptionActive', $subscription);
   }
 
@@ -132,11 +132,16 @@ class Bento_Helper_Orders
   private function sendSubscriptionEvent($name, $subscription)
   {
     $bento_options = get_option('bento_settings');
-    $bento_site_key = $bento_options['bento_site_key'];
 
-    if (empty($bento_site_key)) {
+    if (
+      ! $bento_options ||
+      ! array_key_exists( 'bento_site_key', $bento_options ) ||
+      empty( $bento_options['bento_site_key'] )
+    ) {
       return;
     }
+
+    $bento_site_key = $bento_options['bento_site_key'];
 
     // $details = [
     //  'cart' => [
@@ -166,11 +171,16 @@ class Bento_Helper_Orders
   private function sendEvent($name, $order)
   {
     $bento_options = get_option('bento_settings');
-    $bento_site_key = $bento_options['bento_site_key'];
 
-    if (empty($bento_site_key)) {
+    if (
+      ! $bento_options ||
+      ! array_key_exists( 'bento_site_key', $bento_options ) ||
+      empty( $bento_options['bento_site_key'] )
+    ) {
       return;
     }
+
+    $bento_site_key = $bento_options['bento_site_key'];
 
     $details = [
       'cart' => [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gulp-uglify": "^3.0.1",
     "prettier": "^2.0.5"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "dependencies": {
     "const": "^1.0.0",
     "gulp-uglify-es": "^2.0.0"


### PR DESCRIPTION
This PR fixes a PHP warning that is displayed when initially activating the plugin - at least until you specify a site key and save settings:

> Warning: Trying to access array offset on value of type bool in /bento-wordpress-sdk/inc/custom.php on line 24

Adding some extra conditionals before attempting to embed the script, that requires the site key, prevents this warning from being shown :)