### PR TITLE
Conditionally include unique key only if order exists

### DIFF
--- a/inc/events-controllers/class-woocommerce-subscriptions-bento-events.php
+++ b/inc/events-controllers/class-woocommerce-subscriptions-bento-events.php
@@ -147,9 +147,6 @@ if ( class_exists( 'WC_Subscriptions' ) && ! class_exists( 'WooCommerce_Subscrip
             $order = $subscription->get_last_order( 'all' );
 
             $details = array(
-                'unique' => array(
-                    'key' => $order->get_order_key(),
-                ),
                 'subscription' => array(
                     'id'     => $subscription->get_id(),
                     'status' => $subscription->get_status(),
@@ -158,6 +155,11 @@ if ( class_exists( 'WC_Subscriptions' ) && ! class_exists( 'WooCommerce_Subscrip
                     ),
                 ),
             );
+			if ( $order ) {
+				$details['unique'] = array(
+					'key' => $order->get_order_key(),
+				);
+			}
 
             return $details;
         }


### PR DESCRIPTION
Fixes #19  
Tested this on my own install and this resolves the fatal in cases where an event is triggered without an associated order object.